### PR TITLE
Adding MistuneJSONError and MistuneJSONValidationError

### DIFF
--- a/src/mistune_json/__init__.py
+++ b/src/mistune_json/__init__.py
@@ -5,7 +5,8 @@ A renderer for Mistune that outputs Markdown as JSON structures
 instead of HTML.
 """
 
+from .exceptions import MistuneJSONError, MistuneJSONValidationError
 from .json_renderer import JsonRenderer
 
 __version__ = "0.1.0"
-__all__ = ["JsonRenderer"]
+__all__ = ["JsonRenderer", "MistuneJSONError", "MistuneJSONValidationError"]

--- a/src/mistune_json/exceptions.py
+++ b/src/mistune_json/exceptions.py
@@ -1,0 +1,13 @@
+"""Custom exceptions for mistune-json."""
+
+
+class MistuneJSONError(Exception):
+    """Base exception for mistune-json."""
+
+    pass
+
+
+class MistuneJSONValidationError(MistuneJSONError):
+    """Raised when input validation fails."""
+
+    pass

--- a/src/mistune_json/json_renderer.py
+++ b/src/mistune_json/json_renderer.py
@@ -2,6 +2,8 @@ from typing import Any, Dict, Iterable, List, Optional
 
 import mistune
 
+from .exceptions import MistuneJSONValidationError
+
 
 class JsonRenderer(mistune.HTMLRenderer):
     """
@@ -15,8 +17,14 @@ class JsonRenderer(mistune.HTMLRenderer):
 
         Args:
             output: Optional dictionary to update with rendered content
+
+        Raises:
+            MistuneJSONValidationError: If output is not a dictionary
         """
-        # No need for escape HTML or skip style in JSON renderer
+        if output is not None and not isinstance(output, dict):
+            raise MistuneJSONValidationError(
+                f"output must be a dictionary, got {type(output).__name__}"
+            )
         super().__init__(escape=False, allow_harmful_protocols=False)
         self._output: Dict[str, Any] = output if output is not None else {}
 

--- a/tests/test_json_renderer.py
+++ b/tests/test_json_renderer.py
@@ -3,7 +3,37 @@ from typing import Any, Dict, List
 
 import mistune
 
-from mistune_json.json_renderer import JsonRenderer
+from mistune_json import JsonRenderer
+from mistune_json.exceptions import MistuneJSONError, MistuneJSONValidationError
+
+
+class TestExceptions(unittest.TestCase):
+    """Test suite for custom exception classes."""
+
+    def test_mistune_json_error_exists(self) -> None:
+        """Test that MistuneJSONError is importable."""
+        self.assertTrue(issubclass(MistuneJSONError, Exception))
+
+    def test_validation_error_exists(self) -> None:
+        """Test that MistuneJSONValidationError is importable."""
+        self.assertTrue(issubclass(MistuneJSONValidationError, MistuneJSONError))
+
+    def test_invalid_output_raises_validation_error(self) -> None:
+        """Test that non-dict output raises MistuneJSONValidationError."""
+        with self.assertRaises(MistuneJSONValidationError) as ctx:
+            JsonRenderer(output="not a dict")
+
+        self.assertIn("must be a dictionary", str(ctx.exception))
+
+    def test_invalid_output_list_raises_validation_error(self) -> None:
+        """Test that list output raises MistuneJSONValidationError."""
+        with self.assertRaises(MistuneJSONValidationError):
+            JsonRenderer(output=["not", "a", "dict"])
+
+    def test_valid_dict_output_works(self) -> None:
+        """Test that valid dict output is accepted."""
+        renderer = JsonRenderer(output={"key": "value"})
+        self.assertEqual(renderer._output, {"key": "value"})
 
 
 class TestJsonRenderer(unittest.TestCase):


### PR DESCRIPTION
* Added `MistuneJSONValidationError` and  `MistuneJSONError` to allow better exception handling.
* When the `JsonRenderer` is given an `output` parameter, it is checked now that the object is a `dict`.
* Added unit tests