### PR TITLE
Feature: Extensibility hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 # Mistune JSON
 
-
 A JSON renderer for the [Mistune](https://github.com/lepture/mistune) Markdown parser.
 
 ## Supported HTML elements
@@ -31,7 +30,6 @@ pip install mistune-json
 ```
 
 ### Usage
-
 
 ```python
 import mistune
@@ -179,4 +177,3 @@ Contributions are welcome! Feel free to open issues for:
 * **Bugs** - Report problems with the JSON output structure
 
 Repository: [https://github.com/fernandonino/mistune-json](https://github.com/fernandonino/mistune-json)
-

--- a/README.md
+++ b/README.md
@@ -115,6 +115,62 @@ The following elements are not yet supported:
 * Definition lists
 * Task lists
 
+## Extensibility
+
+You can subclass `JsonRenderer` to customize the JSON output by overriding two hooks:
+
+### `create_node(node_type, data)`
+
+Called for every node before it's returned. Override to add custom fields to nodes.
+
+```python
+from mistune_json import JsonRenderer
+
+class CustomRenderer(JsonRenderer):
+    def create_node(self, node_type, data):
+        node = super().create_node(node_type, data)
+        node["source"] = "mistune-json"  # Add source to all nodes
+        return node
+```
+
+### `finalize_output(output)`
+
+Called after all content is rendered. Override to transform the final output.
+
+```python
+from mistune_json import JsonRenderer
+
+class CustomRenderer(JsonRenderer):
+    def finalize_output(self, output):
+        output["meta"] = {"generated_by": "my-app"}
+        return output
+```
+
+### Full Example
+
+```python
+import mistune
+from mistune_json import JsonRenderer
+from datetime import datetime
+
+class CustomRenderer(JsonRenderer):
+    def create_node(self, node_type, data):
+        node = super().create_node(node_type, data)
+        node["rendered_at"] = datetime.now().isoformat()
+        return node
+    
+    def finalize_output(self, output):
+        output["meta"] = {"version": "1.0"}
+        return output
+
+renderer = CustomRenderer()
+markdown = mistune.create_markdown(renderer=renderer)
+result = markdown("# Hello")
+
+# Each node now has 'rendered_at', and output has 'meta'
+print(result)
+```
+
 ## Contributing and Feedback
 
 Contributions are welcome! Feel free to open issues for:

--- a/src/mistune_json/exceptions.py
+++ b/src/mistune_json/exceptions.py
@@ -11,3 +11,4 @@ class MistuneJSONValidationError(MistuneJSONError):
     """Raised when input validation fails."""
 
     pass
+

--- a/src/mistune_json/json_renderer.py
+++ b/src/mistune_json/json_renderer.py
@@ -55,6 +55,34 @@ class JsonRenderer(mistune.HTMLRenderer):
         for tok in tokens:
             yield self.render_token(tok, state)
 
+    def create_node(
+        self, node_type: str, data: Dict[str, Any]
+    ) -> Dict[str, Any]:
+        """
+        Create a node dictionary. Override to customize node structure.
+
+        Args:
+            node_type: The type of the node (e.g., 'p', 'h', 'code')
+            data: The node data dictionary
+
+        Returns:
+            The node dictionary with type field added
+        """
+        data["type"] = node_type
+        return data
+
+    def finalize_output(self, output: Dict[str, Any]) -> Dict[str, Any]:
+        """
+        Finalize the output. Override to transform the final output.
+
+        Args:
+            output: The output dictionary
+
+        Returns:
+            The finalized output dictionary
+        """
+        return output
+
     def __call__(self, tokens: Iterable[Dict[str, Any]], state: Any) -> Dict[str, Any]:
         """
         Main entry point for rendering.
@@ -67,10 +95,9 @@ class JsonRenderer(mistune.HTMLRenderer):
             Dictionary with rendered content
         """
         content = self.render_tokens(tokens, state)
-        # Filter out empty items
         filtered_content = [item for item in content if item]
         self._output.update({"content": filtered_content})
-        return self._output
+        return self.finalize_output(self._output)
 
     # Block level tokens
 
@@ -80,76 +107,73 @@ class JsonRenderer(mistune.HTMLRenderer):
 
     def paragraph(self, text: str) -> Dict[str, Any]:
         """Render a paragraph."""
-        return {"type": "p", "content": text}
+        return self.create_node("p", {"content": text})
 
     def heading(self, text: str, level: int) -> Dict[str, Any]:
         """Render a heading."""
-        return {"type": "h", "content": text, "level": level}
+        return self.create_node("h", {"content": text, "level": level})
 
     def block_code(self, code: str, info: Optional[str] = None) -> Dict[str, Any]:
         """Render a code block."""
-        result = {"type": "code", "content": code.strip()}
+        result = {"content": code.strip()}
         if info:
             result["lang"] = info.strip()
-        return result
+        return self.create_node("code", result)
 
     def block_quote(self, text: str) -> Dict[str, Any]:
         """Render a block quote."""
-        return {"type": "blockquote", "content": text}
+        return self.create_node("blockquote", {"content": text})
 
     def list(self, text: str, ordered: bool, **attrs: int) -> Dict[str, Any]:
         """Render an ordered or unordered list."""
+        node_type = "ol" if ordered else "ul"
+        result = {"content": text}
         if ordered:
-            result = {"type": "ol", "content": text}
             start = attrs.get("start")
             if start is not None:
                 result["start"] = start
-            return result
-        else:
-            return {"type": "ul", "content": text}
+        return self.create_node(node_type, result)
 
     def list_item(self, text: str) -> Dict[str, Any]:
         """Render a list item."""
-        return {"content": text}
+        return self.create_node("item", {"content": text})
 
     def thematic_break(self) -> Dict[str, Any]:
         """Render a thematic break (horizontal rule)."""
-        return {"type": "hr"}
+        return self.create_node("hr", {})
 
     # Span level tokens
 
     def strong(self, text: str) -> Dict[str, Any]:
         """Render strong emphasis."""
-        return {"type": "strong", "content": text}
+        return self.create_node("strong", {"content": text})
 
     def emphasis(self, text: str) -> Dict[str, Any]:
         """Render emphasis."""
-        return {"type": "em", "content": text}
+        return self.create_node("em", {"content": text})
 
     def codespan(self, text: str) -> Dict[str, Any]:
         """Render inline code."""
-        return {"type": "codespan", "content": text}
+        return self.create_node("codespan", {"content": text})
 
     def link(self, text: str, url: str, title: Optional[str] = None) -> Dict[str, Any]:
         """Render a link."""
-        link = {"type": "a", "href": self.safe_url(url), "content": text}
+        link = {"href": self.safe_url(url), "content": text}
         if title:
             link["title"] = title
-        return link
+        return self.create_node("a", link)
 
     def image(self, text: str, url: str, title: Optional[str] = None) -> Dict[str, Any]:
         """Render an image."""
-        return {
-            "type": "img",
-            "src": self.safe_url(url),
-            "alt": text,
-            **({"title": title} if title else {}),
-        }
+        img = {"src": self.safe_url(url), "alt": text}
+        if title:
+            img["title"] = title
+        return self.create_node("img", img)
 
     def linebreak(self) -> Dict[str, Any]:
         """Render a line break."""
-        return {"type": "br"}
+        return self.create_node("br", {})
 
     def text(self, text: str) -> Dict[str, Any]:
         """Render plain text."""
-        return {"type": "text", "content": text}
+        return self.create_node("text", {"content": text})

--- a/tests/test_json_renderer.py
+++ b/tests/test_json_renderer.py
@@ -36,6 +36,67 @@ class TestExceptions(unittest.TestCase):
         self.assertEqual(renderer._output, {"key": "value"})
 
 
+class TestExtensibilityHooks(unittest.TestCase):
+    """Test suite for extensibility hooks."""
+
+    def test_create_node_hook(self) -> None:
+        """Test that create_node can be overridden."""
+
+        class CustomRenderer(JsonRenderer):
+            def create_node(self, node_type, data):
+                node = super().create_node(node_type, data)
+                node["custom_field"] = "added"
+                return node
+
+        renderer = CustomRenderer()
+        node = renderer.paragraph("test")
+
+        self.assertEqual(node["type"], "p")
+        self.assertEqual(node["content"], "test")
+        self.assertEqual(node["custom_field"], "added")
+
+    def test_finalize_output_hook(self) -> None:
+        """Test that finalize_output can be overridden."""
+
+        class CustomRenderer(JsonRenderer):
+            def finalize_output(self, output):
+                output["meta"] = {"version": "1.0"}
+                return output
+
+        renderer = CustomRenderer()
+        markdown = mistune.create_markdown(renderer=renderer)
+        result = markdown("# Hello")
+
+        self.assertIn("meta", result)
+        self.assertEqual(result["meta"]["version"], "1.0")
+        self.assertIn("content", result)
+
+    def test_hooks_applied_to_integration(self) -> None:
+        """Test hooks work in full integration."""
+
+        class CustomRenderer(JsonRenderer):
+            def create_node(self, node_type, data):
+                node = super().create_node(node_type, data)
+                if node_type != "blank":
+                    node["rendered"] = True
+                return node
+
+            def finalize_output(self, output):
+                output["document"] = {"processed": True}
+                return output
+
+        renderer = CustomRenderer()
+        markdown = mistune.create_markdown(renderer=renderer)
+        result = markdown("# Title\n\nParagraph.")
+
+        self.assertEqual(result["document"]["processed"], True)
+        self.assertIn("content", result)
+
+        for item in result["content"]:
+            if item:
+                self.assertTrue(item.get("rendered", False))
+
+
 class TestJsonRenderer(unittest.TestCase):
     """Test suite for the JsonRenderer class."""
 


### PR DESCRIPTION
Two methods were added: `create_node` and `finalize_output`.

#### `create_node`
This method allows to run custom logic after each node is rendered.

#### `finalize_output`
This method runs once after the rendering logic is finished running.

See the README for a complete usage example.