### PR TITLE
Refactor generator

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,34 @@
+name: CI
+
+on:
+  push:
+    branches: [master, develop]
+  pull_request:
+    branches: [master]
+
+jobs:
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - run: pip install ruff
+      - run: ruff check src/ tests/
+
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - run: pip install poetry
+      - run: poetry install --with dev
+      - run: poetry run pytest --cov=mistune_json --cov-report=xml
+      - uses: codecov/codecov-action@v4
+        with:
+          file: ./coverage.xml

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.0] - 2025-05-19
+
+### Added
+
+- Custom exceptions: `MistuneJSONError` and `MistuneJSONValidationError`
+- Extensibility hooks: `create_node()` and `finalize_output()` for subclass customization
+- Documentation noting that `render_tokens()` and `iter_tokens()` are used internally by Mistune
+
+### Changed
+
+- All render methods now use `create_node()` for building node dictionaries
+
 ## [0.1.0] - 2024-12-15
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - All render methods now use `create_node()` for building node dictionaries
+- Optimized `__call__` to use `filter()` for removing empty items (more Pythonic)
 
 ## [0.1.0] - 2024-12-15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,29 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.1.0] - 2024-12-15
+
+### Added
+
+- Initial release of mistune-json
+- JSON renderer for Mistune Markdown parser
+- Support for the following HTML elements:
+  - Paragraph (`<p>`)
+  - Image (`<img>`)
+  - Ordered lists (`<ol>`)
+  - Unordered lists (`<ul>`)
+  - Heading elements (`<h1>` through `<h6>`)
+  - Links (`<a>`)
+  - Emphasis (`<em>`)
+  - Strong (`<strong>`)
+  - Blockquote (`<blockquote>`)
+  - Line break (`<br>`)
+  - Thematic break (`<hr>`)
+  - Inline and block code
+- Optional `output` parameter for pre-populating output dictionary
+- Unit tests for all rendered elements
+

--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
 # Mistune JSON
+
 A JSON renderer for the [Mistune](https://github.com/lepture/mistune) Markdown parser.
 
 ## Supported HTML elements
+
 So far, the HTML elements supported by this renderer are limited to:
 
 * Paragraph, `<p>`
@@ -18,13 +20,17 @@ So far, the HTML elements supported by this renderer are limited to:
 * Both inline and block code
 
 ## How to use the JSON renderer
+
 ### Installation
-The package is not yet published in PyPI, but once it is, it will be installed with:
+
+The package is published in PyPI, so it can be installed through `pip` (as any other package):
+
 ```shell
 pip install mistune-json
 ```
 
 ### Usage
+
 ```python
 import mistune
 from mistune_json import JsonRenderer
@@ -39,16 +45,80 @@ markdown = mistune.create_markdown(renderer=renderer)
 result = markdown("# Hello, world!")
 
 print(result)
-# {'content': [{'type': 'h', 'content': ['type': 'text', 'content': 'Hello, world!'], 'level': 1}]}
+# {'content': [{'type': 'h', 'content': [{'type': 'text', 'content': 'Hello, world!'}], 'level': 1}]}
 ```
 
-## Improvements and bugs
+## Output Schema
 
-### Tables
-There is currently no support for rendering tables (headers and rows). It might be added in the future, if there is enough need for it. You can rise an issue [here](https://github.com/fernandonino/mistune-json/issues) and label it as _enhancement_.
+The JSON output is a dictionary with a `content` key containing a list of nodes. Each node has a `type` field identifying its kind.
 
-### Integration testing
-Tests for a full Markdown document will be added to assure that the JSON render works as expected.
+### Node Types
 
-### Bugs
-If you find a problem with the JSON output structure, feel free to [report a bug](https://github.com/fernandonino/mistune-json/issues).
+| Type | Description | Fields |
+|------|-------------|--------|
+| `text` | Plain text content | `content` (str) |
+| `p` | Paragraph | `content` (list of inline nodes) |
+| `h` | Heading (h1-h6) | `content` (list), `level` (int 1-6) |
+| `code` | Code block (fenced) | `content` (str), `lang` (str, optional) |
+| `codespan` | Inline code | `content` (str) |
+| `blockquote` | Block quote | `content` (list of inline nodes) |
+| `ol` | Ordered list | `content` (str), `start` (int, optional) |
+| `ul` | Unordered list | `content` (str) |
+| `a` | Link | `content` (str), `href` (str), `title` (str, optional) |
+| `img` | Image | `src` (str), `alt` (str), `title` (str, optional) |
+| `em` | Emphasis (italic) | `content` (str) |
+| `strong` | Strong (bold) | `content` (str) |
+| `hr` | Thematic break (horizontal rule) | - |
+| `br` | Line break | - |
+
+### Example
+
+Input:
+
+```markdown
+# Title
+
+This is a paragraph with **bold** and *italic* text.
+
+![alt text](image.png)
+
+- Item 1
+- Item 2
+```
+
+Output:
+
+```json
+{
+  "content": [
+    {"type": "h", "content": [{"type": "text", "content": "Title"}], "level": 1},
+    {"type": "p", "content": [
+      {"type": "text", "content": "This is a paragraph with "},
+      {"type": "strong", "content": "bold"},
+      {"type": "text", "content": " and "},
+      {"type": "em", "content": "italic"},
+      {"type": "text", "content": " text."}
+    ]},
+    {"type": "img", "src": "image.png", "alt": "alt text"},
+    {"type": "ul", "content": "..."}
+  ]
+}
+```
+
+## Limitations
+
+The following elements are not yet supported:
+
+* Tables (headers and rows)
+* Definition lists
+* Task lists
+
+## Contributing and Feedback
+
+Contributions are welcome! Feel free to open issues for:
+
+* **Enhancements** - Request new features or supported elements
+* **Bugs** - Report problems with the JSON output structure
+
+Repository: [https://github.com/fernandonino/mistune-json](https://github.com/fernandonino/mistune-json)
+

--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 # Mistune JSON
 
-
 A JSON renderer for the [Mistune](https://github.com/lepture/mistune) Markdown parser.
 
 ## Supported HTML elements
@@ -31,7 +30,6 @@ pip install mistune-json
 ```
 
 ### Usage
-
 
 ```python
 import mistune
@@ -179,4 +177,3 @@ Contributions are welcome! Feel free to open issues for:
 * **Bugs** - Report problems with the JSON output structure
 
 Repository: [https://github.com/fernandonino/mistune-json](https://github.com/fernandonino/mistune-json)
-

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ pip install mistune-json
 
 ### Usage
 
+
 ```python
 import mistune
 from mistune_json import JsonRenderer

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # Mistune JSON
 
+
 A JSON renderer for the [Mistune](https://github.com/lepture/mistune) Markdown parser.
 
 ## Supported HTML elements

--- a/README.md
+++ b/README.md
@@ -115,6 +115,62 @@ The following elements are not yet supported:
 * Definition lists
 * Task lists
 
+## Extensibility
+
+You can subclass `JsonRenderer` to customize the JSON output by overriding two hooks:
+
+### `create_node(node_type, data)`
+
+Called for every node before it's returned. Override to add custom fields to nodes.
+
+```python
+from mistune_json import JsonRenderer
+
+class CustomRenderer(JsonRenderer):
+    def create_node(self, node_type, data):
+        node = super().create_node(node_type, data)
+        node["source"] = "mistune-json"  # Add source to all nodes
+        return node
+```
+
+### `finalize_output(output)`
+
+Called after all content is rendered. Override to transform the final output.
+
+```python
+from mistune_json import JsonRenderer
+
+class CustomRenderer(JsonRenderer):
+    def finalize_output(self, output):
+        output["meta"] = {"generated_by": "my-app"}
+        return output
+```
+
+### Full Example
+
+```python
+import mistune
+from mistune_json import JsonRenderer
+from datetime import datetime
+
+class CustomRenderer(JsonRenderer):
+    def create_node(self, node_type, data):
+        node = super().create_node(node_type, data)
+        node["rendered_at"] = datetime.now().isoformat()
+        return node
+    
+    def finalize_output(self, output):
+        output["meta"] = {"version": "1.0"}
+        return output
+
+renderer = CustomRenderer()
+markdown = mistune.create_markdown(renderer=renderer)
+result = markdown("# Hello")
+
+# Each node now has 'rendered_at', and output has 'meta'
+print(result)
+```
+
 ## Contributing and Feedback
 
 Contributions are welcome! Feel free to open issues for:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,13 +1,21 @@
 [project]
 name = "mistune-json"
 version = "0.1.0"
-description = ""
+description = "A JSON renderer for the Mistune Markdown parser"
+readme = "README.md"
+license = "MIT"
+requires-python = ">=3.12"
+keywords = ["markdown", "json", "renderer", "mistune", "converter", "parser"]
+classifiers = [
+    "Development Status :: 5 - Production/Stable",
+    "Intended Audience :: Developers",
+    "License :: OSI Approved :: MIT License",
+    "Programming Language :: Python :: 3.12",
+    "Topic :: Software Development :: Libraries :: Python Modules",
+]
 authors = [
     {name = "fernandonino",email = "nino.fernando@gmail.com"}
 ]
-readme = "README.md"
-license= "MIT"
-requires-python = ">=3.12"
 dependencies = [
     "mistune (>=3.1.3,<4.0.0)",
 ]

--- a/src/mistune_json/__init__.py
+++ b/src/mistune_json/__init__.py
@@ -5,7 +5,8 @@ A renderer for Mistune that outputs Markdown as JSON structures
 instead of HTML.
 """
 
+from .exceptions import MistuneJSONError, MistuneJSONValidationError
 from .json_renderer import JsonRenderer
 
 __version__ = "0.1.0"
-__all__ = ["JsonRenderer"]
+__all__ = ["JsonRenderer", "MistuneJSONError", "MistuneJSONValidationError"]

--- a/src/mistune_json/exceptions.py
+++ b/src/mistune_json/exceptions.py
@@ -11,3 +11,4 @@ class MistuneJSONValidationError(MistuneJSONError):
     """Raised when input validation fails."""
 
     pass
+

--- a/src/mistune_json/exceptions.py
+++ b/src/mistune_json/exceptions.py
@@ -1,0 +1,13 @@
+"""Custom exceptions for mistune-json."""
+
+
+class MistuneJSONError(Exception):
+    """Base exception for mistune-json."""
+
+    pass
+
+
+class MistuneJSONValidationError(MistuneJSONError):
+    """Raised when input validation fails."""
+
+    pass

--- a/src/mistune_json/json_renderer.py
+++ b/src/mistune_json/json_renderer.py
@@ -32,6 +32,8 @@ class JsonRenderer(mistune.HTMLRenderer):
         """
         Render a list of tokens into JSON structures.
 
+        Note: This method is used internally by Mistune. Override with caution.
+
         Args:
             tokens: Iterable of tokens to render
             state: State object from Mistune parser
@@ -44,6 +46,8 @@ class JsonRenderer(mistune.HTMLRenderer):
     def iter_tokens(self, tokens: Iterable[Dict[str, Any]], state: Any) -> Iterable[Dict[str, Any]]:
         """
         Iterate through tokens and yield rendered JSON structures.
+
+        Note: This method is used internally by Mistune. Override with caution.
 
         Args:
             tokens: Iterable of tokens to render

--- a/src/mistune_json/json_renderer.py
+++ b/src/mistune_json/json_renderer.py
@@ -99,8 +99,7 @@ class JsonRenderer(mistune.HTMLRenderer):
             Dictionary with rendered content
         """
         content = self.render_tokens(tokens, state)
-        filtered_content = [item for item in content if item]
-        self._output.update({"content": filtered_content})
+        self._output.update({"content": list(filter(None, content))})
         return self.finalize_output(self._output)
 
     # Block level tokens

--- a/src/mistune_json/json_renderer.py
+++ b/src/mistune_json/json_renderer.py
@@ -2,6 +2,8 @@ from typing import Any, Dict, Iterable, List, Optional
 
 import mistune
 
+from .exceptions import MistuneJSONValidationError
+
 
 class JsonRenderer(mistune.HTMLRenderer):
     """
@@ -15,8 +17,14 @@ class JsonRenderer(mistune.HTMLRenderer):
 
         Args:
             output: Optional dictionary to update with rendered content
+
+        Raises:
+            MistuneJSONValidationError: If output is not a dictionary
         """
-        # No need for escape HTML or skip style in JSON renderer
+        if output is not None and not isinstance(output, dict):
+            raise MistuneJSONValidationError(
+                f"output must be a dictionary, got {type(output).__name__}"
+            )
         super().__init__(escape=False, allow_harmful_protocols=False)
         self._output: Dict[str, Any] = output if output is not None else {}
 

--- a/src/mistune_json/json_renderer.py
+++ b/src/mistune_json/json_renderer.py
@@ -55,6 +55,34 @@ class JsonRenderer(mistune.HTMLRenderer):
         for tok in tokens:
             yield self.render_token(tok, state)
 
+    def create_node(
+        self, node_type: str, data: Dict[str, Any]
+    ) -> Dict[str, Any]:
+        """
+        Create a node dictionary. Override to customize node structure.
+
+        Args:
+            node_type: The type of the node (e.g., 'p', 'h', 'code')
+            data: The node data dictionary
+
+        Returns:
+            The node dictionary with type field added
+        """
+        data["type"] = node_type
+        return data
+
+    def finalize_output(self, output: Dict[str, Any]) -> Dict[str, Any]:
+        """
+        Finalize the output. Override to transform the final output.
+
+        Args:
+            output: The output dictionary
+
+        Returns:
+            The finalized output dictionary
+        """
+        return output
+
     def __call__(self, tokens: Iterable[Dict[str, Any]], state: Any) -> Dict[str, Any]:
         """
         Main entry point for rendering.
@@ -67,10 +95,9 @@ class JsonRenderer(mistune.HTMLRenderer):
             Dictionary with rendered content
         """
         content = self.render_tokens(tokens, state)
-        # Filter out empty items
         filtered_content = [item for item in content if item]
         self._output.update({"content": filtered_content})
-        return self._output
+        return self.finalize_output(self._output)
 
     # Block level tokens
 
@@ -80,76 +107,73 @@ class JsonRenderer(mistune.HTMLRenderer):
 
     def paragraph(self, text: str) -> Dict[str, Any]:
         """Render a paragraph."""
-        return {"type": "p", "content": text}
+        return self.create_node("p", {"content": text})
 
     def heading(self, text: str, level: int) -> Dict[str, Any]:
         """Render a heading."""
-        return {"type": "h", "content": text, "level": level}
+        return self.create_node("h", {"content": text, "level": level})
 
     def block_code(self, code: str, info: Optional[str] = None) -> Dict[str, Any]:
         """Render a code block."""
-        result = {"type": "code", "content": code.strip()}
+        result = {"content": code.strip()}
         if info:
             result["lang"] = info.strip()
-        return result
+        return self.create_node("code", result)
 
     def block_quote(self, text: str) -> Dict[str, Any]:
         """Render a block quote."""
-        return {"type": "blockquote", "content": text}
+        return self.create_node("blockquote", {"content": text})
 
     def list(self, text: str, ordered: bool, **attrs: int) -> Dict[str, Any]:
         """Render an ordered or unordered list."""
+        node_type = "ol" if ordered else "ul"
+        result = {"content": text}
         if ordered:
-            result = {"type": "ol", "content": text}
             start = attrs.get("start")
             if start is not None:
                 result["start"] = start
-            return result
-        else:
-            return {"type": "ul", "content": text}
+        return self.create_node(node_type, result)
 
     def list_item(self, text: str) -> Dict[str, Any]:
         """Render a list item."""
-        return {"content": text}
+        return self.create_node("item", {"content": text})
 
     def thematic_break(self) -> Dict[str, Any]:
         """Render a thematic break (horizontal rule)."""
-        return {"type": "hr"}
+        return self.create_node("hr", {})
 
     # Span level tokens
 
     def strong(self, text: str) -> Dict[str, Any]:
         """Render strong emphasis."""
-        return {"type": "strong", "content": text}
+        return self.create_node("strong", {"content": text})
 
     def emphasis(self, text: str) -> Dict[str, Any]:
         """Render emphasis."""
-        return {"type": "em", "content": text}
+        return self.create_node("em", {"content": text})
 
     def codespan(self, text: str) -> Dict[str, Any]:
         """Render inline code."""
-        return {"type": "codespan", "content": text}
+        return self.create_node("codespan", {"content": text})
 
     def link(self, text: str, url: str, title: Optional[str] = None) -> Dict[str, Any]:
         """Render a link."""
-        link = {"type": "a", "href": self.safe_url(url), "content": text}
+        link = {"href": self.safe_url(url), "content": text}
         if title:
             link["title"] = title
-        return link
+        return self.create_node("a", link)
 
     def image(self, text: str, url: str, title: Optional[str] = None) -> Dict[str, Any]:
         """Render an image."""
-        return {
-            "type": "img",
-            "src": self.safe_url(url),
-            "alt": text,
-            **({"title": title} if title else {}),
-        }
+        img = {"src": self.safe_url(url), "alt": text}
+        if title:
+            img["title"] = title
+        return self.create_node("img", img)
 
     def linebreak(self) -> Dict[str, Any]:
         """Render a line break."""
-        return {"type": "br"}
+        return self.create_node("br", {})
 
     def text(self, text: str) -> Dict[str, Any]:
         """Render plain text."""
-        return {"type": "text", "content": text}
+        return self.create_node("text", {"content": text})

--- a/tests/test_json_renderer.py
+++ b/tests/test_json_renderer.py
@@ -43,7 +43,9 @@ class TestExtensibilityHooks(unittest.TestCase):
         """Test that create_node can be overridden."""
 
         class CustomRenderer(JsonRenderer):
-            def create_node(self, node_type, data):
+            def create_node(
+                self, node_type: str, data: Dict[str, Any]
+            ) -> Dict[str, Any]:
                 node = super().create_node(node_type, data)
                 node["custom_field"] = "added"
                 return node
@@ -59,7 +61,7 @@ class TestExtensibilityHooks(unittest.TestCase):
         """Test that finalize_output can be overridden."""
 
         class CustomRenderer(JsonRenderer):
-            def finalize_output(self, output):
+            def finalize_output(self, output: Dict[str, Any]) -> Dict[str, Any]:
                 output["meta"] = {"version": "1.0"}
                 return output
 
@@ -75,13 +77,15 @@ class TestExtensibilityHooks(unittest.TestCase):
         """Test hooks work in full integration."""
 
         class CustomRenderer(JsonRenderer):
-            def create_node(self, node_type, data):
+            def create_node(
+                self, node_type: str, data: Dict[str, Any]
+            ) -> Dict[str, Any]:
                 node = super().create_node(node_type, data)
                 if node_type != "blank":
                     node["rendered"] = True
                 return node
 
-            def finalize_output(self, output):
+            def finalize_output(self, output: Dict[str, Any]) -> Dict[str, Any]:
                 output["document"] = {"processed": True}
                 return output
 

--- a/tests/test_json_renderer.py
+++ b/tests/test_json_renderer.py
@@ -3,7 +3,37 @@ from typing import Any, Dict, List
 
 import mistune
 
-from mistune_json.json_renderer import JsonRenderer
+from mistune_json import JsonRenderer
+from mistune_json.exceptions import MistuneJSONError, MistuneJSONValidationError
+
+
+class TestExceptions(unittest.TestCase):
+    """Test suite for custom exception classes."""
+
+    def test_mistune_json_error_exists(self) -> None:
+        """Test that MistuneJSONError is importable."""
+        self.assertTrue(issubclass(MistuneJSONError, Exception))
+
+    def test_validation_error_exists(self) -> None:
+        """Test that MistuneJSONValidationError is importable."""
+        self.assertTrue(issubclass(MistuneJSONValidationError, MistuneJSONError))
+
+    def test_invalid_output_raises_validation_error(self) -> None:
+        """Test that non-dict output raises MistuneJSONValidationError."""
+        with self.assertRaises(MistuneJSONValidationError) as ctx:
+            JsonRenderer(output="not a dict")
+
+        self.assertIn("must be a dictionary", str(ctx.exception))
+
+    def test_invalid_output_list_raises_validation_error(self) -> None:
+        """Test that list output raises MistuneJSONValidationError."""
+        with self.assertRaises(MistuneJSONValidationError):
+            JsonRenderer(output=["not", "a", "dict"])
+
+    def test_valid_dict_output_works(self) -> None:
+        """Test that valid dict output is accepted."""
+        renderer = JsonRenderer(output={"key": "value"})
+        self.assertEqual(renderer._output, {"key": "value"})
 
 
 class TestJsonRenderer(unittest.TestCase):

--- a/tests/test_json_renderer.py
+++ b/tests/test_json_renderer.py
@@ -36,6 +36,67 @@ class TestExceptions(unittest.TestCase):
         self.assertEqual(renderer._output, {"key": "value"})
 
 
+class TestExtensibilityHooks(unittest.TestCase):
+    """Test suite for extensibility hooks."""
+
+    def test_create_node_hook(self) -> None:
+        """Test that create_node can be overridden."""
+
+        class CustomRenderer(JsonRenderer):
+            def create_node(self, node_type, data):
+                node = super().create_node(node_type, data)
+                node["custom_field"] = "added"
+                return node
+
+        renderer = CustomRenderer()
+        node = renderer.paragraph("test")
+
+        self.assertEqual(node["type"], "p")
+        self.assertEqual(node["content"], "test")
+        self.assertEqual(node["custom_field"], "added")
+
+    def test_finalize_output_hook(self) -> None:
+        """Test that finalize_output can be overridden."""
+
+        class CustomRenderer(JsonRenderer):
+            def finalize_output(self, output):
+                output["meta"] = {"version": "1.0"}
+                return output
+
+        renderer = CustomRenderer()
+        markdown = mistune.create_markdown(renderer=renderer)
+        result = markdown("# Hello")
+
+        self.assertIn("meta", result)
+        self.assertEqual(result["meta"]["version"], "1.0")
+        self.assertIn("content", result)
+
+    def test_hooks_applied_to_integration(self) -> None:
+        """Test hooks work in full integration."""
+
+        class CustomRenderer(JsonRenderer):
+            def create_node(self, node_type, data):
+                node = super().create_node(node_type, data)
+                if node_type != "blank":
+                    node["rendered"] = True
+                return node
+
+            def finalize_output(self, output):
+                output["document"] = {"processed": True}
+                return output
+
+        renderer = CustomRenderer()
+        markdown = mistune.create_markdown(renderer=renderer)
+        result = markdown("# Title\n\nParagraph.")
+
+        self.assertEqual(result["document"]["processed"], True)
+        self.assertIn("content", result)
+
+        for item in result["content"]:
+            if item:
+                self.assertTrue(item.get("rendered", False))
+
+
 class TestJsonRenderer(unittest.TestCase):
     """Test suite for the JsonRenderer class."""
 


### PR DESCRIPTION
The current code in `__call__` does:

```python
content = self.render_tokens(tokens, state)  # Returns list
filtered_content = [item for item in content if item]  # Creates new list
```

This builds an intermediate list twice (once in render_tokens, once in filtering).

It's going to be replaced by using the built-in function `filter()`.