### PR TITLE
Refactor: __call__ method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - All render methods now use `create_node()` for building node dictionaries
+- Optimized `__call__` to use `filter()` for removing empty items (more Pythonic)
 
 ## [0.1.0] - 2024-12-15
 

--- a/src/mistune_json/json_renderer.py
+++ b/src/mistune_json/json_renderer.py
@@ -99,8 +99,7 @@ class JsonRenderer(mistune.HTMLRenderer):
             Dictionary with rendered content
         """
         content = self.render_tokens(tokens, state)
-        filtered_content = [item for item in content if item]
-        self._output.update({"content": filtered_content})
+        self._output.update({"content": list(filter(None, content))})
         return self.finalize_output(self._output)
 
     # Block level tokens


### PR DESCRIPTION
The current code in `__call__` does:

```python
content = self.render_tokens(tokens, state)  # Returns list
filtered_content = [item for item in content if item]  # Creates new list
```

This builds an intermediate list twice (once in render_tokens, once in filtering).

It's going to be replaced by using the built-in function `filter()`.